### PR TITLE
Added method to make easy to use with text

### DIFF
--- a/src/secure-string.js
+++ b/src/secure-string.js
@@ -9,7 +9,7 @@ function SecureString () {
   let encryptedValue
   let key = crypto.randomBytes(cipherSize)
   let iv = crypto.randomBytes(16)
-  
+
   function value(fn) {
     const cipher = crypto.createDecipheriv(cipherName, key, iv)
     const a = cipher.update(encryptedValue)
@@ -23,7 +23,7 @@ function SecureString () {
       crypto.randomFillSync(c)
     }
   }
-  
+
   function clear() {
     if (encryptedValue) {
       crypto.randomFillSync(encryptedValue)
@@ -31,27 +31,34 @@ function SecureString () {
     const cipher = crypto.createCipheriv(cipherName, key, iv)
     encryptedValue = Buffer.concat([cipher.update(''), cipher.final()])
   }
-  
+
   function appendCodePoint (codePoint) {
     let cipher = crypto.createDecipheriv(cipherName, key, iv)
     const a = cipher.update(encryptedValue)
     const b = cipher.final()
-    
+
     cipher = crypto.createCipheriv(cipherName, key, iv)
     encryptedValue = Buffer.concat([
-      cipher.update(a), 
+      cipher.update(a),
       cipher.update(b),
       cipher.update(Buffer.from(String.fromCodePoint(codePoint))),
       cipher.final()])
     crypto.randomFillSync(a)
     crypto.randomFillSync(b)
   }
-  
+
   clear()
-  
+
   this.value = value
   this.appendCodePoint = appendCodePoint
   this.clear = clear
+}
+
+SecureString.fromText = function(text) {
+  const ss = new SecureString()
+  Buffer.from(text).forEach(ss.appendCodePoint)
+  text = null
+  return ss
 }
 
 module.exports = SecureString

--- a/test/ask.js
+++ b/test/ask.js
@@ -13,7 +13,7 @@ describe('ask', () => {
     const password = new SecureString()
     expect(SecureString.ask).to.exist()
   })
-  
+
   it.skip('returns a secure string', done => {
     SecureString.ask('password', (err, answer) => {
       expect(err).to.not.exist()

--- a/test/secure-string.spec.js
+++ b/test/secure-string.spec.js
@@ -12,7 +12,7 @@ describe('SecureString', () => {
     const password = new SecureString()
     expect(password).to.be.instanceOf(SecureString)
   })
-  
+
   it('plain text is a buffer', () => {
     const password = new SecureString()
     password.value(plainText => {
@@ -21,7 +21,7 @@ describe('SecureString', () => {
       expect(plainText.toString()).to.equal('')
     })
   })
-  
+
   it('plain text is a UTF-8 encoded buffer', () => {
     const password = new SecureString()
     password.appendCodePoint(0x41)
@@ -77,5 +77,12 @@ describe('SecureString', () => {
     password.value(plainText => {
       expect(plainText.toString()).to.equal('')
     })
+  })
+
+  it('can be created from a static method', () => {
+    const secret = 'is it really secure?'
+    const password = SecureString.fromText(secret)
+    password.value(plainText =>
+      expect(plainText.toString()).to.be.equal(secret))
   })
 })


### PR DESCRIPTION
I plan to use this lib a lot and inside some config files, so would be great to use it like this way:

```
{ passwd: SecureString.fromText('my-text') }
```

Btw, great work and thanks!